### PR TITLE
Updated Android SMS permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,23 @@ enum PermissionName {
   // Android
   Sensors,
   // Android
-  SMS,
+  SEND_SMS,
+  // Android
+  RECEIVE_SMS,
+  // Android
+  READ_SMS,
+  // Android
+  RECEIVE_WAP_PUSH,
+  // Android
+  RECEIVE_MMS,
   // Android
   Storage
 }
 ```
 
-####Android:
+#### Android:
 
-Only dangerous permissions require user agreement. 
+Only dangerous permissions require user agreement.
 
 Permissions are organized into groups related to a device's capabilities or features. Under this system, permission requests are handled at the group level and a single permission group corresponds to several permission declarations in the app manifest.
 
@@ -43,7 +51,7 @@ Dangerous permissions and permission groups.
         <td>Permissions</td>
     </tr>
     <tr>
-        <td rowspan="2">CALENDAR</td> 
+        <td rowspan="2">CALENDAR</td>
         <td >READ_CALENDAR</td>
     </tr>
     <tr>
@@ -123,7 +131,11 @@ Dangerous permissions and permission groups.
     <tr>
         <td >WRITE_EXTERNAL_STORAGE</td>
     </tr>
-</table>	
+</table>
+
+Effective January 2019, Google has added new restrictions to applications with SMS Permissions.
+In order to publish an App on the Play Store with SMS permissions, it must have consent from Google or
+be set as the default SMS app. For more information please see https://play.google.com/about/privacy-security-deception/permissions/
 
 Make sure you add the needed permissions to your Android Manifest Permission.
 
@@ -157,7 +169,7 @@ Make sure you add the needed permissions to your Android Manifest Permission.
 
 #### iOS
 
- Add the needed permissions to your info.plist
+Add the needed permissions to your info.plist
 
 ```objective-c
  <key>NSCalendarsUsageDescription</key>
@@ -197,4 +209,4 @@ PermissionStatus permissionStatus = await Permission.requestSinglePermission(Per
 Permission.openSettings;
 ```
 
-#### 
+####

--- a/android/src/main/java/com/ly/permission/PermissionPlugin.java
+++ b/android/src/main/java/com/ly/permission/PermissionPlugin.java
@@ -118,8 +118,20 @@ public class PermissionPlugin implements MethodCallHandler, PluginRegistry.Reque
             case "Sensors":
                 result = Manifest.permission.BODY_SENSORS;
                 break;
-            case "SMS":
+            case "READ_SMS":
                 result = Manifest.permission.READ_SMS;
+                break;
+            case "SEND_SMS":
+                result = Manifest.permission.SEND_SMS;
+                break;
+            case "RECEIVE_SMS":
+                result = Manifest.permission.RECEIVE_SMS;
+                break;
+            case "RECEIVE_WAP_PUSH":
+                result = Manifest.permission.RECEIVE_WAP_PUSH;
+                break;
+            case "RECEIVE_MMS":
+                result = Manifest.permission.RECEIVE_MMS;
                 break;
             case "Storage":
                 result = Manifest.permission.READ_EXTERNAL_STORAGE;


### PR DESCRIPTION
Using the default SMS group, a user did not gain access to SEND_SMS. This has been updated by splitting the group into 5 categories. Each permission with its own request. This is for two reasons, 1 it fixes above mentioned issue and 2 it allows for better SMS permission control with the new Developer Policy implemented by Google. To use SMS permissions on the Play Store must have permission via Google or be set as the default SMS application. 